### PR TITLE
Updating google provider versions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What does this do?
 
-Creates an Elastic Cloud Deployment with traffic filter rules to only allow traffic from allowed IPs and the VPC of the accompanying GCP project.
+Creates an Elastic Cloud Deployment. By default, it includes traffic filter rules to only allow traffic from allowed IPs and the VPC of the accompanying GCP project.
 
 ## How to provision this module?
 
@@ -98,8 +98,8 @@ module "elasticsearch" {
 |------|---------|
 | <a name="requirement_ec"></a> [ec](#requirement\_ec) | ~> 0.4.0 |
 | <a name="requirement_elasticstack"></a> [elasticstack](#requirement\_elasticstack) | ~> 0.3.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 4.0.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 4.0 |
 
 ## Providers
 
@@ -107,8 +107,8 @@ module "elasticsearch" {
 |------|---------|
 | <a name="provider_ec"></a> [ec](#provider\_ec) | ~> 0.4.0 |
 | <a name="provider_elasticstack"></a> [elasticstack](#provider\_elasticstack) | ~> 0.3.3 |
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.0.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 4.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 4.0 |
 
 ## Modules
 

--- a/header.txt
+++ b/header.txt
@@ -2,7 +2,7 @@
 
 ## What does this do?
 
-Creates an Elastic Cloud Deployment with traffic filter rules to only allow traffic from allowed IPs and the VPC of the accompanying GCP project.
+Creates an Elastic Cloud Deployment. By default, it includes traffic filter rules to only allow traffic from allowed IPs and the VPC of the accompanying GCP project.
 
 ## How to provision this module?
 

--- a/network.tf
+++ b/network.tf
@@ -35,8 +35,6 @@ resource "google_dns_record_set" "psc_managed_zone_record" {
 }
 
 resource "google_dns_managed_zone" "psc_managed_zone" {
-  provider = google-beta
-
   name        = var.project_name == null ? "${var.project_id}-private-zone" : "${var.project_name}-private-zone"
   project     = var.project_id
   dns_name    = local.elastic_private_dns[var.region]

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0.0"
+      version = "~> 4.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.0.0"
+      version = "~> 4.0"
     }
     ec = {
       source  = "elastic/ec"


### PR DESCRIPTION
Updates provider version constraints to be in line with base project repos. This requires allowing the google and google-beta providers to be any version of 4.x.x. 