### PR TITLE
Enabling request id - necessary for api errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ No modules.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project id. | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | A name variable used to name the resources. Should only be set if deploying to a Gen 2 project | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region for the deployment | `string` | `"us-west1"` | no |
+| <a name="input_request_id"></a> [request\_id](#input\_request\_id) | This variable is sometimes needed when the Elastic API encounters an error. Only set this if told to by the output of a Terraform apply | `string` | `null` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | The name of the VPC network of the GKE cluster we want to allow communication from | `string` | `"gke-application-cluster-vpc"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ resource "ec_deployment" "elastic_cloud_deployment" {
   region                 = "gcp-${var.region}"
   version                = var.elastic_version
   deployment_template_id = var.elastic_deployment_template_name
+  request_id             = var.request_id
 
   traffic_filter = var.make_public ? null : [
     ec_deployment_traffic_filter.filter_allowed_ips[0].id,

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,9 @@ variable "disable_psc" {
   type        = bool
   default     = false
 }
+
+variable "request_id" {
+  description = "This variable is sometimes needed when the Elastic API encounters an error. Only set this if told to by the output of a Terraform apply"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
The request id is sometimes required when the Terraform provider encounters an API error. There will be output from the Terraform apply that will say `set "request_id" to [REQUEST_ID] to recreate the deployment resources`. This helps the Terraform provider reconcile its state with the Elastic Cloud state. This variable should only be set if there is an API error. 