### PR TITLE
Enable autoscaling by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,9 @@ resource "ec_deployment" "elastic_cloud_deployment" {
         user_settings_yaml = file("${path.module}/elasticsearch.yml")
       }
     }
+    // If a topology is set, this ensures autoscaling will be turned off since turning on autoscaling when a topology is set causes
+    // issues with the Elastic Cloud provider. Issue: https://github.com/elastic/terraform-provider-ec/issues/467
+    autoscale = var.elastic_autoscaling && length(var.elastic_topology) == 0
   }
 
   kibana {

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "enable_anonymous_access" {
   default     = false
 }
 
+variable "elastic_autoscaling" {
+  description = "This will enable autoscaling on the elasticsearch instances. If elastic_toplogy is set, this should not be set to true"
+  type        = bool
+  default     = true
+}
+
 variable "elastic_topology" {
   description = "Configuration settings list for desired Elasticsearch topologies. See https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment#topology for definitions of topology settings."
   type = list(object({
@@ -76,16 +82,7 @@ variable "elastic_topology" {
       max_size = string
     })
   }))
-  default = [
-    {
-      id         = "hot_content"
-      size       = "4g"
-      zone_count = 3
-      autoscaling = {
-        max_size = "64g"
-      }
-    }
-  ]
+  default = []
 }
 
 variable "kibana_topology" {


### PR DESCRIPTION
Changes the elasticsearch configuration to enable autoscaling by default. However, there is a [known issue](https://github.com/elastic/terraform-provider-ec/issues/467) where enabling autoscaling while defining a custom topology causes issues with the terraform provider. As such, autoscaling will only be enabled if both the autoscaling variable is set to true AND there is not a custom topology defined.

I have also removed the default topology since the  deployment template will set a default topology which does work well with autoscaling.