### PR TITLE
Fix GCP networking by adding forwarding rule

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  # List of Private DNS addresses provided by Elastic: https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-html
+  # List of Private DNS addresses provided by Elastic: https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-psc.html#ec-private-service-connect-uris
   # If adding a region, make sure to add the `.` at the end and to remove `psc` from the front.
   elastic_private_dns = {
     "asia-east1"              = "asia-east1.gcp.elastic-cloud.com."
@@ -19,5 +19,25 @@ locals {
     "us-east1"                = "us-east1.gcp.elastic-cloud.com."
     "us-east4"                = "us-east4.gcp.elastic-cloud.com."
     "us-west1"                = "us-west1.gcp.cloud.es.io."
+  }
+  # List of Service Attachment URIs provided by Elastic: https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-psc.html#ec-private-service-connect-uris
+  service_attachment_uris = {
+    "asia-east1"              = "projects/cloud-production-168820/regions/asia-east1/serviceAttachments/proxy-psc-production-asia-east1-v1-attachment"
+    "asia-northeast1"         = "projects/cloud-production-168820/regions/asia-northeast1/serviceAttachments/proxy-psc-production-asia-northeast1-v1-attachment"
+    "asia-northeast3"         = "projects/cloud-production-168820/regions/asia-northeast3/serviceAttachments/proxy-psc-production-asia-northeast3-v1-attachment"
+    "asia-south1"             = "projects/cloud-production-168820/regions/asia-south1/serviceAttachments/proxy-psc-production-asia-south1-v1-attachment"
+    "asia-southeast1"         = "projects/cloud-production-168820/regions/asia-southeast1/serviceAttachments/proxy-psc-production-asia-southeast1-v1-attachment"
+    "australia-southeast1"    = "projects/cloud-production-168820/regions/australia-southeast1/serviceAttachments/proxy-psc-production-australia-southeast1-v1-attachment"
+    "europe-north1"           = "projects/cloud-production-168820/regions/europe-north1/serviceAttachments/proxy-psc-production-europe-north1-v1-attachment"
+    "europe-west1"            = "projects/cloud-production-168820/regions/europe-west1/serviceAttachments/proxy-psc-production-europe-west1-v1-attachment"
+    "europe-west2"            = "projects/cloud-production-168820/regions/europe-west2/serviceAttachments/proxy-psc-production-europe-west2-v1-attachment"
+    "europe-west3"            = "projects/cloud-production-168820/regions/europe-west3/serviceAttachments/proxy-psc-production-europe-west3-v1-attachment"
+    "europe-west4"            = "projects/cloud-production-168820/regions/europe-west4/serviceAttachments/proxy-psc-production-europe-west4-v1-attachment"
+    "northamerica-northeast1" = "projects/cloud-production-168820/regions/northamerica-northeast1/serviceAttachments/proxy-psc-production-northamerica-northeast1-v1-attachment"
+    "southamerica-east1"      = "projects/cloud-production-168820/regions/southamerica-east1/serviceAttachments/proxy-psc-production-southamerica-east1-v1-attachment"
+    "us-central1"             = "projects/cloud-production-168820/regions/us-central1/serviceAttachments/proxy-psc-production-us-central1-v1-attachment"
+    "us-east1"                = "projects/cloud-production-168820/regions/us-east1/serviceAttachments/proxy-psc-production-us-east1-v1-attachment"
+    "us-east4"                = "projects/cloud-production-168820/regions/us-east4/serviceAttachments/proxy-psc-production-us-east4-v1-attachment"
+    "us-west1"                = "projects/cloud-production-168820/regions/us-west1/serviceAttachments/proxy-psc-production-us-west1-v1-attachment"
   }
 }

--- a/network.tf
+++ b/network.tf
@@ -28,6 +28,16 @@ resource "google_compute_address" "psc_address" {
   subnetwork   = data.google_compute_network.network[0].subnetworks_self_links[0]
 }
 
+resource "google_compute_forwarding_rule" "psc_forwarding_rule" {
+  name                  = var.project_name == null ? "${var.project_id}-psc-forwarding-rule" : "${var.project_name}-psc-forwarding-rule"
+  load_balancing_scheme = ""
+  region                = var.region
+  project               = var.project_id
+  ip_address            = google_compute_address.psc_address[0].id
+  target                = local.service_attachment_uris[var.region]
+  network               = data.google_compute_network.network[0].id
+}
+
 # DNS Management
 resource "google_dns_record_set" "psc_managed_zone_record" {
   count = var.disable_psc ? 0 : 1


### PR DESCRIPTION
This change addresses the issues the ES module now has where the Private Service connect is not being created. The forwarding rule (for reasons that are beyond me, it feels like the configuration before should not have worked) corrects the issue and ensures the successful creation of the PSC and enables successful traffic forwarding from the GKE cluster to the ES deployments.

Contributes to https://github.com/dapperlabs/SRE/issues/2630