### PR TITLE
Ignore EC Deployment version setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,12 @@ resource "ec_deployment" "elastic_cloud_deployment" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      version,
+    ]
+  }
 }
 
 # Filter rule to allow requests from allowed IPs


### PR DESCRIPTION
As Elastic Cloud versioning and their Terraform provider are annoying we are adding an ignore lifecycle rule to ignore the EC stack version so that we do not get unwanted upgrades. 

NOTE: This will block any upgrade being initiated from Terraform. With how the EC TF provider is architected, we will not be able to upgrade any deployment unless we manually log into Elastic Cloud and run the upgrade there. This is tech debt that will have to be fixed at a future date.