### PR TITLE
FIX-proper-count-for-forwarding-fule

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -29,6 +29,8 @@ resource "google_compute_address" "psc_address" {
 }
 
 resource "google_compute_forwarding_rule" "psc_forwarding_rule" {
+  count = var.disable_psc ? 0 : 1
+
   name                  = var.project_name == null ? "${var.project_id}-psc-forwarding-rule" : "${var.project_name}-psc-forwarding-rule"
   load_balancing_scheme = ""
   region                = var.region


### PR DESCRIPTION
I forgot to add the count setting for the forwarding rule. This is necessary for when you don't want to use a Private Service connect object and is similar to all the other networking resources that go into creating the PSC.