### PR TITLE
Adding ability to define observability deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,13 @@ resource "ec_deployment" "elastic_cloud_deployment" {
     }
   }
 
+  dynamic "observability" {
+    for_each = var.observability_deployment == null ? toset([]) : toset([1])
+    content {
+      deployment_id = var.observability_deployment
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       version,

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,9 @@ variable "request_id" {
   type        = string
   default     = null
 }
+
+variable "observability_deployment" {
+  description = "Cluster id of deployment to send logs to"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Adds the ability to define an observability cluster to send metrics to from the main elastic cloud cluster. To enable, define the variable and as it's value set it to the cluster id of the logging cluster.

This is included as an emergency fix to the studio-platform project as they needed to enable a logging cluster during a fire.